### PR TITLE
[Feat/#38] 캐러셀이 정상적으로 로드되지 않고 같은 글 중복 로드

### DIFF
--- a/src/app/_component/main/FilterableArticleList.tsx
+++ b/src/app/_component/main/FilterableArticleList.tsx
@@ -7,11 +7,13 @@ import { Article } from "../../../api/types";
 import { ArticleCard } from "../../../components/ArticleCard/ArticleCard";
 
 const getSessionStorageItem = (key: string, defaultValue: any) => {
+  if (typeof window === "undefined") return defaultValue;
   const item = sessionStorage.getItem(key);
   return item ? JSON.parse(item) : defaultValue;
 };
 
 const setSessionStorageItem = (key: string, value: any) => {
+  if (typeof window === "undefined") return;
   sessionStorage.setItem(key, JSON.stringify(value));
 };
 

--- a/src/app/_component/main/Popular.tsx
+++ b/src/app/_component/main/Popular.tsx
@@ -54,7 +54,7 @@ const PrevArrow = (props: any) => {
 const Popular = ({ topArticles }: PopularProp) => {
   const settings = {
     dots: false,
-    infinite: true,
+    infinite: topArticles.length > 1,
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
@@ -76,7 +76,7 @@ const Popular = ({ topArticles }: PopularProp) => {
         }}
       >
         <Slider {...settings}>
-          {topArticles.map(item => (
+          {[...topArticles].map(item => (
             <ArticleCard
               key={item.pageId}
               pageId={item.pageId}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->

## 관련된 이슈 넘버

<!-- close #1 -->
closes #47 #38 

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- typeof window === undefined 이슈
- 1개의 아이템일 때 react-slick infinite 활성화면 렌더링 이슈

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
<!-- Screenshot, References 기재 -->
- react-slick 이슈
https://github.com/akiran/react-slick/issues/2405

- window type이슈
아래와 같이 typeof window === undefined인 부분을 활용합니다.
```ts
const getSessionStorageItem = (key: string, defaultValue: any) => {
  if (typeof window === "undefined") return defaultValue;
  const item = sessionStorage.getItem(key);
  return item ? JSON.parse(item) : defaultValue;
};
```
### NextStep
같은 고민을 한 SafeSessionStorage를SessionStorage를 사용할 수 있도록 개선합니다.
https://github.com/team-moeum/moeum-design-system/blob/c60342915053a3c19e5c69e95fc24e4b7dc94b75/packages/moeum-components/src/shared/storage/SessionStorage.ts