### PR TITLE
[Feat/#41] 반응이 적용 안되는 이슈

### DIFF
--- a/src/components/GiscusBlock/GiscusBlock.tsx
+++ b/src/components/GiscusBlock/GiscusBlock.tsx
@@ -17,7 +17,7 @@ export default function GiscusBlock() {
     scriptElem.crossOrigin = "anonymous";
 
     const giscusAttributes = {
-      "data-repo": "fotcamp/tech-blog",
+      "data-repo": "team-moeum/tech-blog",
       "data-repo-id": "R_kgDOMge0hw",
       "data-category": "Comments",
       "data-category-id": "DIC_kwDOMge0h84CihXP",


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
로그인 후에도 giscus 컴포넌트의 반응과 댓글이 적용 안되는 이슈입니다.
<!-- PR 설명 -->

## 관련된 이슈 넘버
close #41 
<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- team-moeum으로 org이 바뀌면서 조회를 하지 못하는 문제가 발생하였습니다.

[적용 결과]
![스크린샷 2025-01-01 오전 11 28 12](https://github.com/user-attachments/assets/ecbb91b9-4891-44dd-a9c3-19a5ab80a89a)


## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC
```diff
-      "data-repo": "fotcamp/tech-blog",
+      "data-repo": "team-moeum/tech-blog",
```
<!-- Screenshot, References 기재 -->
